### PR TITLE
TT-2001 Added CORS-configuration to remove 401-error in frontend

### DIFF
--- a/src/main/kotlin/no/nb/tekst/tekst_auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/no/nb/tekst/tekst_auth/config/SecurityConfig.kt
@@ -6,14 +6,31 @@ import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.web.server.SecurityWebFilterChain
+import org.springframework.web.cors.reactive.CorsConfigurationSource
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource
+import org.springframework.web.cors.reactive.CorsWebFilter
 
 @Configuration
 @EnableWebFluxSecurity
 class SecurityConfig {
 
     @Bean
+    fun corsWebFilter(): CorsWebFilter {
+        val config = CorsConfiguration().apply {
+            allowedOrigins = listOf("http://localhost:4200")
+            allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            allowedHeaders = listOf("*")
+            allowCredentials = true
+        }
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", config)
+        return CorsWebFilter(source)
+    }
+
+    @Bean
     fun springSecurityFilterChain(http: ServerHttpSecurity): SecurityWebFilterChain {
-        http.csrf { csrf -> csrf.disable() }.authorizeExchange { exchange ->
+        http.csrf { csrf -> csrf.disable() }.cors {}.authorizeExchange { exchange ->
             exchange
                 .pathMatchers(
                     "/",


### PR DESCRIPTION
La til CORS som tillater oppkoblinger fra localhost:4200, da fungerte DIMO frontend som forventet